### PR TITLE
Update google_fonts to support fira code

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -98,7 +98,7 @@ theme_color:           rgb(8,46,57)
 
 # The string encoding which fonts to fetch from Google Fonts.
 # See: <https://hydejack.com/docs/configuration/>
-google_fonts:          Roboto+Slab:700|Noto+Sans:400,400i,700,700i
+google_fonts:          Fira+Code|Roboto+Slab:700|Noto+Sans:400,400i,700,700i
 
 # The text font. Expects a string that is a valid CSS font-family value.
 # To change font-weight, see _sass/variables.scss


### PR DESCRIPTION
Add Fira Code to the google_fonts for the font_code

From what I've checked, Fira Code (which is the default font for the coding block) did not worked.